### PR TITLE
Issue #50: HTTP errors are ignored and result in empty responses with…

### DIFF
--- a/src/main/java/io/ipinfo/api/IPinfo.java
+++ b/src/main/java/io/ipinfo/api/IPinfo.java
@@ -6,6 +6,7 @@ import com.google.gson.reflect.TypeToken;
 import io.ipinfo.api.cache.Cache;
 import io.ipinfo.api.cache.SimpleCache;
 import io.ipinfo.api.context.Context;
+import io.ipinfo.api.errors.InvalidTokenException;
 import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.ASNResponse;
 import io.ipinfo.api.model.IPResponse;
@@ -60,7 +61,7 @@ public class IPinfo {
      * @return IPResponse response from the api.
      * @throws RateLimitedException an exception when your api key has been rate limited.
      */
-    public IPResponse lookupIP(String ip) throws RateLimitedException {
+    public IPResponse lookupIP(String ip) throws RateLimitedException, InvalidTokenException {
         IPResponse response = (IPResponse)cache.get(cacheKey(ip));
         if (response != null) {
             return response;
@@ -80,7 +81,7 @@ public class IPinfo {
      * @return ASNResponse response from the api.
      * @throws RateLimitedException an exception when your api key has been rate limited.
      */
-    public ASNResponse lookupASN(String asn) throws RateLimitedException {
+    public ASNResponse lookupASN(String asn) throws RateLimitedException, InvalidTokenException {
         ASNResponse response = (ASNResponse)cache.get(cacheKey(asn));
         if (response != null) {
             return response;
@@ -100,7 +101,7 @@ public class IPinfo {
      * @return String the URL to the map.
      * @throws RateLimitedException an exception when your API key has been rate limited.
      */
-    public String getMap(List<String> ips) throws RateLimitedException {
+    public String getMap(List<String> ips) throws RateLimitedException, InvalidTokenException {
         MapResponse response = new MapRequest(client, token, ips).handle();
         return response.getReportUrl();
     }
@@ -374,6 +375,9 @@ public class IPinfo {
         }
 
         public IPinfo build() {
+            if (token == null || token.isEmpty()) {
+                throw new IllegalArgumentException("A token must be provided.");
+            }
             return new IPinfo(client, new Context(), token, cache);
         }
     }

--- a/src/main/java/io/ipinfo/api/errors/ClientErrorException.java
+++ b/src/main/java/io/ipinfo/api/errors/ClientErrorException.java
@@ -1,0 +1,12 @@
+package io.ipinfo.api.errors;
+
+/**
+ * <p>This exception is raised when a client error is occurring (Http status code like 4xx).</p>
+ *
+ * <p>Note that HTTP status 403 (Forbidden) is now reported as a checked exception of type @see InvalidTokenException .</p>
+ */
+public class ClientErrorException extends HttpErrorException {
+    public ClientErrorException(int statusCode, String message) {
+        super(statusCode, message);
+    }
+}

--- a/src/main/java/io/ipinfo/api/errors/HttpErrorException.java
+++ b/src/main/java/io/ipinfo/api/errors/HttpErrorException.java
@@ -1,0 +1,17 @@
+package io.ipinfo.api.errors;
+
+/**
+ * This covers all non 403 and 429 Http error statuses.
+ */
+public class HttpErrorException extends RuntimeException {
+    private final int statusCode;
+
+    public HttpErrorException(int statusCode, String message) {
+        super(message);
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/io/ipinfo/api/errors/InvalidTokenException.java
+++ b/src/main/java/io/ipinfo/api/errors/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package io.ipinfo.api.errors;
+
+/**
+ * <p>This exception is raised when the service returns a 403 (access denied).</p>
+ *
+ * <p>That likely indicates that the token is either missing, incorrect or expired.
+ * It is a checked exception so, if you have multiple tokens (example during transition), you can fall back to another token.</p>
+ */
+public class InvalidTokenException extends Exception {
+    public InvalidTokenException() {
+        super("The server did not accepted the provided token or no token was provided.");
+    }
+}

--- a/src/main/java/io/ipinfo/api/errors/ServerErrorException.java
+++ b/src/main/java/io/ipinfo/api/errors/ServerErrorException.java
@@ -1,0 +1,10 @@
+package io.ipinfo.api.errors;
+
+/**
+ * This exception is raised when a server error is returned by IpInfo (Http status like 5xx)
+ */
+public class ServerErrorException extends HttpErrorException {
+    public ServerErrorException(int statusCode, String message) {
+        super(statusCode, message);
+    }
+}

--- a/src/main/java/io/ipinfo/api/request/ASNRequest.java
+++ b/src/main/java/io/ipinfo/api/request/ASNRequest.java
@@ -1,6 +1,7 @@
 package io.ipinfo.api.request;
 
 import io.ipinfo.api.errors.ErrorResponseException;
+import io.ipinfo.api.errors.InvalidTokenException;
 import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.ASNResponse;
 import okhttp3.OkHttpClient;
@@ -18,7 +19,7 @@ public class ASNRequest extends BaseRequest<ASNResponse> {
     }
 
     @Override
-    public ASNResponse handle() throws RateLimitedException {
+    public ASNResponse handle() throws RateLimitedException, InvalidTokenException {
         String url = String.format(URL_FORMAT, asn);
         Request.Builder request = new Request.Builder().url(url).get();
 

--- a/src/main/java/io/ipinfo/api/request/IPRequest.java
+++ b/src/main/java/io/ipinfo/api/request/IPRequest.java
@@ -1,6 +1,7 @@
 package io.ipinfo.api.request;
 
 import io.ipinfo.api.errors.ErrorResponseException;
+import io.ipinfo.api.errors.InvalidTokenException;
 import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.IPResponse;
 import okhttp3.OkHttpClient;
@@ -19,7 +20,7 @@ public class IPRequest extends BaseRequest<IPResponse> {
     }
 
     @Override
-    public IPResponse handle() throws RateLimitedException {
+    public IPResponse handle() throws RateLimitedException, InvalidTokenException {
         if (isBogon(ip)) {
             try {
                 return new IPResponse(ip, true);

--- a/src/main/java/io/ipinfo/api/request/MapRequest.java
+++ b/src/main/java/io/ipinfo/api/request/MapRequest.java
@@ -1,6 +1,7 @@
 package io.ipinfo.api.request;
 
 import io.ipinfo.api.errors.ErrorResponseException;
+import io.ipinfo.api.errors.InvalidTokenException;
 import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.MapResponse;
 import okhttp3.*;
@@ -17,7 +18,7 @@ public class MapRequest extends BaseRequest<MapResponse> {
     }
 
     @Override
-    public MapResponse handle() throws RateLimitedException {
+    public MapResponse handle() throws RateLimitedException, InvalidTokenException {
         String jsonIpList = gson.toJson(ips);
         RequestBody requestBody = RequestBody.create(null, jsonIpList);
         Request.Builder request = new Request.Builder().url(URL).post(requestBody);

--- a/src/test/java/io/ipinfo/IPinfoTest.java
+++ b/src/test/java/io/ipinfo/IPinfoTest.java
@@ -2,6 +2,7 @@ package io.ipinfo;
 
 import io.ipinfo.api.IPinfo;
 import io.ipinfo.api.errors.ErrorResponseException;
+import io.ipinfo.api.errors.InvalidTokenException;
 import io.ipinfo.api.errors.RateLimitedException;
 import io.ipinfo.api.model.ASNResponse;
 import io.ipinfo.api.model.IPResponse;
@@ -56,7 +57,7 @@ public class IPinfoTest {
             () -> assertEquals(bogonResp.getIp(), "2001:0:c000:200::0:255:1"),
             () -> assertTrue(bogonResp.getBogon())
             );
-        } catch (RateLimitedException e) {
+        } catch (RateLimitedException | InvalidTokenException e) {
             fail(e);
         }
     }
@@ -69,7 +70,7 @@ public class IPinfoTest {
 
         try {
             String mapUrl = ii.getMap(Arrays.asList("1.1.1.1", "2.2.2.2", "8.8.8.8"));
-        } catch (RateLimitedException e) {
+        } catch (RateLimitedException | InvalidTokenException e) {
             fail(e);
         }
     }


### PR DESCRIPTION
… cache poisoning.

WARNING This change is not a drop in replacement as if we get 403 because the token is incorrect, a checked exception is raised. 

Also note that, if an empty or null token is passed, it is now a fail fast (instead of getting a null pointer exception at the first request)